### PR TITLE
Fix bytes count on UTF-8 error

### DIFF
--- a/cld2/__init__.py
+++ b/cld2/__init__.py
@@ -393,7 +393,7 @@ def detect(utf8Bytes, isPlainText=True, hintTopLevelDomain=None,  # noqa
             raise ValueError("input contains invalid UTF-8 around byte " +
                              "%d (of %d)" % (
                                  cld_results.valid_prefix_bytes,
-                                 cld_results.bytes_found))
+                                 len(utf8Bytes)-1))
         elif ret_code != 0:
             raise ValueError("Unknown Error !")
 

--- a/cld2/binding.cc
+++ b/cld2/binding.cc
@@ -140,11 +140,12 @@ extern "C" {
                                                 &valid_prefix_bytes);
 
         results->reliable = is_reliable;
-        results->bytes_found = text_bytes_found;
         results->valid_prefix_bytes = valid_prefix_bytes;
 
         if (valid_prefix_bytes < num_bytes)
             return 3;
+
+        results->bytes_found = text_bytes_found;
 
         for(int idx=0; idx<3; idx++) {
             CLD2::Language lang = language3[idx];


### PR DESCRIPTION
cld2 only accepts a subset of UTF-8, called "Interchange valid UTF-8"
(https://tools.ietf.org/html/rfc5198) which does not accept control
characters. (We get this error a lot in production.)

When such a character is found, bytes_found is not set, so use the
number of bytes instead, as is done in DetectLanguageCheckUTF8.