### PR TITLE
Fix untrue doc comment about `utf8Bytes`

### DIFF
--- a/cld2/__init__.py
+++ b/cld2/__init__.py
@@ -246,9 +246,10 @@ def detect(utf8Bytes, isPlainText=True, hintTopLevelDomain=None,  # noqa
 
     Parameters
     ----------
-    utf8Bytes : unicode
-        The text to detect, encoded as UTF-8 bytes (required).  If this is not
-        valid UTF-8, then an ValueError is raised.
+    utf8Bytes : str or bytes
+        The text to detect, as a Unicode string (`str`) in Python 3, or
+        encoded as UTF-8 bytes (`bytes` in Python 3 or `str` in Python 2).
+        If passed as bytes and not valid UTF-8, then a ValueError is raised.
 
     isPlainText : bool, optional
         If False, then the input is HTML and CLD will skip HTML tags, expand


### PR DESCRIPTION
The actual code has accepted Unicode strings (type `str`) in Python 3 [for a long time](https://github.com/GregBowyer/cld2-cffi/commit/c401d2be06e522c87027135f81ae96b146a76c31). In both Python 2 and 3, `utf8Bytes` can be of a type named `str`. In Python 2, that's a byte string type, and the bytes must be UTF-8. In Python 3 it is a Unicode string type, and string will be converted to UTF-8 bytes. In Python 3 the argument can also be of type `bytes`, which is equivalent to passing a `str` (byte string) in Python 2, so likewise it must be UTF-8 encoded.